### PR TITLE
Fix self-play population alignment

### DIFF
--- a/batch_arena.py
+++ b/batch_arena.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import pickle
 import os
+import argparse
 import torch
 import math
 import random
@@ -38,7 +39,7 @@ DNA_SIZE = GENE_N * GENE_SIZE
 OFFSPRING = 2
 GAMES_PER_MATE = 10
 
-DEVICE = 'cuda'
+DEVICE = 'cuda' if torch.cuda.is_available() else 'cpu'
 
 
 def is_winner(board, player):
@@ -120,10 +121,12 @@ def generate_perfect_moves():
 
 def get_losing_move_ratio(player_instance):
   if os.path.isfile('perfect_moves.pkl'):
-    perfect_dataset = pickle.load(open('perfect_moves.pkl', 'rb'))
+    with open('perfect_moves.pkl', 'rb') as f:
+      perfect_dataset = pickle.load(f)
   else:
     perfect_dataset = generate_perfect_moves()
-    pickle.dump(perfect_dataset, open('perfect_moves.pkl', 'wb'))
+    with open('perfect_moves.pkl', 'wb') as f:
+      pickle.dump(perfect_dataset, f)
   test_player = Players(splice_params(player_instance.params, [0]))
   losing_moves = 0
   total = 0
@@ -242,7 +245,8 @@ class Players():
     self.weights = None
 
     if os.path.isfile('perfect_moves.pkl'):
-      self.perfect_dataset = pickle.load(open('perfect_moves.pkl', 'rb'))
+      with open('perfect_moves.pkl', 'rb') as f:
+        self.perfect_dataset = pickle.load(f)
     else:
       self.perfect_dataset = generate_perfect_moves()
 
@@ -316,6 +320,7 @@ class Players():
   def mate(self,):
     cred = self.params['credits']
     bs = len(cred)
+    assert all(len(v) == bs for v in self.params.values()), "population parameter tensors must stay aligned"
     can_mate = torch.argsort(cred, descending=True)
     print(torch.max(cred), torch.min(cred), len(can_mate), torch.mean(abs(cred).float()))
     print(self.params['credits'][can_mate][:10], self.params['x_games'][can_mate][:10])
@@ -330,8 +335,8 @@ class Players():
       if key in ['credits', 'x_games']:
         continue
       repro_params[key] = self.params[key][can_mate,None,:].repeat(1, OFFSPRING, 1).reshape((bs, self.params[key].shape[1]))
-    repro_params['credits'] = torch.zeros((bs*2), dtype=torch.long, device=DEVICE)
-    repro_params['x_games'] = torch.zeros((bs*2), dtype=torch.long, device=DEVICE)
+    repro_params['credits'] = torch.zeros((bs), dtype=torch.long, device=self.device)
+    repro_params['x_games'] = torch.zeros((bs), dtype=torch.long, device=self.device)
     
 
     self.params = repro_params
@@ -434,12 +439,12 @@ def init_players(bs=BATCH_SIZE):
   players = Players(params)
   return players
 
-def train_run(name='', bs=BATCH_SIZE):
+def train_run(name='', bs=BATCH_SIZE, steps=200000, checkpoint_every=1000):
 
   writer = SummaryWriter(f'runs/{name}')
   players = init_players(bs=bs)
 
-  pbar = tqdm.tqdm(range(200000))
+  pbar = tqdm.tqdm(range(steps))
 
   for step in pbar:
     for _ in range(GAMES_PER_MATE):
@@ -453,7 +458,7 @@ def train_run(name='', bs=BATCH_SIZE):
 
     if step % 100 == 0:
       write_metrics(step, writer, games, a_players, b_players)
-      if step % 1000 == 0 and step > 0:
+      if checkpoint_every and step % checkpoint_every == 0 and step > 0:
         pickle.dump(a_players.params, open('organic_dna.pkl', 'wb'))
         losing_move_ratio = get_losing_move_ratio(a_players)
         writer.add_scalar('losing_move_ratio', losing_move_ratio, step)
@@ -462,7 +467,19 @@ def train_run(name='', bs=BATCH_SIZE):
 
 
 if __name__ == '__main__':
-  for i in range(120,2000):
-    bs = 4000
+  parser = argparse.ArgumentParser()
+  parser.add_argument('--device', default=DEVICE, choices=['cpu', 'cuda'])
+  parser.add_argument('--batch-size', type=int, default=4000)
+  parser.add_argument('--steps', type=int, default=200000)
+  parser.add_argument('--runs', type=int, default=1)
+  parser.add_argument('--start-run', type=int, default=0)
+  parser.add_argument('--checkpoint-every', type=int, default=1000)
+  args = parser.parse_args()
+
+  if args.device == 'cuda' and not torch.cuda.is_available():
+    raise RuntimeError('CUDA requested but unavailable')
+  DEVICE = args.device
+
+  for i in range(args.start_run, args.start_run + args.runs):
     name = f'run_{i}'
-    train_run(name=name, bs=bs)
+    train_run(name=name, bs=args.batch_size, steps=args.steps, checkpoint_every=args.checkpoint_every)

--- a/play.py
+++ b/play.py
@@ -75,7 +75,7 @@ if __name__ == '__main__':
   args = parser.parse_args()
 
   draw_lines()
-  device = 'cuda'
+  device = 'cuda' if torch.cuda.is_available() else 'cpu'
   games = Games(bs=1, device=device)
 
   if args.perfect:

--- a/test_training_invariants.py
+++ b/test_training_invariants.py
@@ -1,0 +1,20 @@
+import unittest
+
+import batch_arena
+
+
+class TrainingInvariantTests(unittest.TestCase):
+  def test_mate_keeps_population_tensors_aligned(self):
+    batch_arena.DEVICE = 'cpu'
+    players = batch_arena.init_players(bs=4)
+    before = players.params['dna'].shape[0]
+
+    players.mate()
+
+    self.assertEqual(players.params['dna'].shape[0], before)
+    for name, value in players.params.items():
+      self.assertEqual(value.shape[0], before, name)
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Fixes a population-accounting bug that blocks reliable self-play training for #2.

After `Players.mate()`, `credits` and `x_games` were reset to `bs * 2` entries while every genome/mutation tensor remained at `bs` entries. The next generation was therefore no longer aligned: selection sorted over twice as many credit entries as there were genomes, and later indexing could select non-existent individuals.

This PR keeps all population tensors at the same length after mating, adds an invariant regression test for that behavior, and removes the CUDA-only startup assumption so short validation runs can execute on CPU-only machines. It does not add hardcoded perfect players; the change is aimed at making the existing self-play loop trainable and reproducible.

Validation run locally on CPU:
- `python -m unittest test_training_invariants.py`
- `python batch_arena.py --device cpu --batch-size 4 --steps 2 --runs 1 --checkpoint-every 0`
- `git diff --check`